### PR TITLE
feat: Add `themes` support to `auto()` and deprecate `theme()`

### DIFF
--- a/.changeset/tricky-facts-rush.md
+++ b/.changeset/tricky-facts-rush.md
@@ -1,0 +1,5 @@
+---
+"vitest-plugin-vis": minor
+---
+
+Add `themes` support to `auto()` and deprecate `theme()`.

--- a/packages/vitest-plugin-vis/src/setup/create_vis.ts
+++ b/packages/vitest-plugin-vis/src/setup/create_vis.ts
@@ -28,12 +28,17 @@ export type VisClientConfigurator<SM extends SnapshotMeta<ComparisonMethod>> = {
 		 * Enable automatic visual testing.
 		 *
 		 * This will take a snapshot after each test.
+		 * If the `themes` option is provided, it will take a snapshot for each theme.
 		 */
-		auto(): void
+		auto<M>(
+			themes?: Record<string, (options: M & SM) => Promise<boolean> | Promise<void> | boolean | void> | undefined,
+		): void
 		/**
 		 * Enable automatic visual testing with multiple themes.
 		 *
 		 * This will take a snapshot after each test for each theme.
+		 *
+		 * @deprecated Use `auto` instead.
 		 *
 		 * @param themes A record of theme names and their setup functions.
 		 *
@@ -70,10 +75,14 @@ export function createVis<SM extends SnapshotMeta<ComparisonMethod>>(commands: S
 			manual() {
 				beforeAll(vis.beforeAll.setup)
 			},
-			auto() {
+			auto(themes) {
 				beforeAll(vis.beforeAll.setup)
-				afterEach(vis.afterEach.matchImageSnapshot)
-				enableAuto()
+				if (themes) {
+					afterEach(vis.afterEach.matchPerTheme(themes))
+				} else {
+					afterEach(vis.afterEach.matchImageSnapshot)
+					enableAuto()
+				}
 			},
 			theme(themes) {
 				beforeAll(vis.beforeAll.setup)


### PR DESCRIPTION
No test added as the `ctx` state mess up other tests.
Will look into cleaning it up in v3 branch