### PR TITLE
fix: Sanitize suite ID to prevent invalid paths

### DIFF
--- a/packages/vitest-plugin-vis/src/server/vis_context.logic.ts
+++ b/packages/vitest-plugin-vis/src/server/vis_context.logic.ts
@@ -183,10 +183,7 @@ export function getSuiteId(
 	options: Pick<VisOptions, 'customizeSnapshotSubpath'>,
 ) {
 	const suiteId = getSnapshotSubpath(relative(state.projectRoot, testPath), options)
-	/**
-	 * Removes any '..' or '../' from the suiteId to prevent invalid file paths
-	 */
-	const parsedSuiteId = suiteId.replaceAll('../', '').replaceAll('..', '')
+	const parsedSuiteId = suiteId.replaceAll('..', '__')
 	return parsedSuiteId
 }
 

--- a/packages/vitest-plugin-vis/src/server/vis_context.logic.ts
+++ b/packages/vitest-plugin-vis/src/server/vis_context.logic.ts
@@ -182,7 +182,12 @@ export function getSuiteId(
 	testPath: string,
 	options: Pick<VisOptions, 'customizeSnapshotSubpath'>,
 ) {
-	return getSnapshotSubpath(relative(state.projectRoot, testPath), options)
+	const suiteId = getSnapshotSubpath(relative(state.projectRoot, testPath), options)
+	/**
+	 * Removes any '..' or '../' from the suiteId to prevent invalid file paths
+	 */
+	const parsedSuiteId = suiteId.replaceAll('../', '').replaceAll('..', '')
+	return parsedSuiteId
 }
 
 function getVisOptions(visOptionsRecord: Record<string, VisOptions<any>>, context: PartialBrowserCommandContext) {


### PR DESCRIPTION
This PR fixes an issue where the getSuiteId function could generate an ID containing directory traversal segments (`..` or `../`) based on the test file's path.

This becomes problematic when the generated `suiteId` is used to construct file paths for output directories. Specifically, the presence of `../` or `..` segments can cause files to be written to incorrect locations instead of the intended `__baselines__`, `__diffs__` , or `__results__` directories relative to the test file, potentially leading to errors or unexpected file structures.

The fix sanitizes the suiteId within the getSuiteId function. It now uses String.prototype.replaceAll to remove all occurrences of both `../` and `..` from the calculated ID before returning it.

This ensures the resulting `suiteId`  is always a clean, relative path segment, preventing invalid path issues and ensuring outputs are written correctly within the expected `__baselines__`, `__diffs__` , and `__results__` directories.