### PR TITLE
Simplify verification job condition in PR workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,7 +9,6 @@ on:
       - '**/__vis__/**/__baselines__/**'
 jobs:
   verify:
-    if: ${{ !startsWith(github.head_ref, 'changeset-release/') }}
     strategy:
       matrix:
         os:


### PR DESCRIPTION
Remove condition to skip verification for changeset-release branches.