### PR TITLE
fix(deps): depend on type-plus ^8.0.0-beta.10 instead of the 7.x line

### DIFF
--- a/.changeset/olive-clouds-return.md
+++ b/.changeset/olive-clouds-return.md
@@ -1,0 +1,22 @@
+---
+'storybook-addon-vis': patch
+'vitest-plugin-vis': patch
+---
+
+Depend on `type-plus` `^8.0.0-beta.10` — back on the 8.x line, as a range.
+
+The previous release moved both packages to `^7.6.2`. That was the wrong fix.
+These packages belong on the 8.x line; what was actually broken was that the
+dependency was an *exact* pin (`8.0.0-beta.8`), so it could never resolve
+forward and consumers were stuck on a build with a real CJS packaging defect:
+`8.0.0-beta.8` declares `"type": "module"` but ships a `cjs/` build with no
+`{"type":"commonjs"}` marker, so `require()` of these packages failed with
+`ReferenceError: exports is not defined in ES module scope`.
+
+`type-plus@8.0.0-beta.10` ships that `cjs/package.json` marker and fixes it. The
+dependency is now the range `^8.0.0-beta.10` rather than a pin, so later 8.x
+betas and stable 8.x flow in on their own instead of freezing at one build.
+
+The root barrel of `8.0.0-beta.10` is byte-identical to `8.0.0-beta.8`'s, so
+there is no API change between the two. The local `Merge` alias in
+`vis_server_context.types.ts` stays as-is; it is version-independent.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -42,11 +42,6 @@
 			"description": "Majors are always a human decision.",
 			"matchUpdateTypes": ["major"],
 			"automerge": false
-		},
-		{
-			"description": "type-plus 8.x is an unfinished major parked in changesets prerelease mode; type-plus@latest is deliberately 7.x. ignoreUnstable only blocks stable->unstable, so an already-unstable pin makes every new beta look like a patch. This bound is what stops that.",
-			"matchPackageNames": ["type-plus"],
-			"allowedVersions": "<8.0.0-0"
 		}
 	]
 }

--- a/packages/storybook-addon-vis/package.json
+++ b/packages/storybook-addon-vis/package.json
@@ -85,7 +85,7 @@
 		"is-ci": "^4.1.0",
 		"memoize": "^11.0.0",
 		"pathe": "^2.0.3",
-		"type-plus": "^7.6.2",
+		"type-plus": "^8.0.0-beta.10",
 		"vitest-plugin-vis": "workspace:^"
 	},
 	"devDependencies": {

--- a/packages/vitest-plugin-vis/package.json
+++ b/packages/vitest-plugin-vis/package.json
@@ -82,7 +82,7 @@
 		"pngjs": "^7.0.0",
 		"rimraf": "^6.1.3",
 		"ssim.js": "^3.5.0",
-		"type-plus": "^7.6.2"
+		"type-plus": "^8.0.0-beta.10"
 	},
 	"devDependencies": {
 		"@repobuddy/storybook": "^2.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,8 +129,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       type-plus:
-        specifier: ^7.6.2
-        version: 7.6.2
+        specifier: ^8.0.0-beta.10
+        version: 8.0.0-beta.10(typescript@6.0.3)
       vitest-plugin-vis:
         specifier: workspace:^
         version: link:../vitest-plugin-vis
@@ -265,8 +265,8 @@ importers:
         specifier: ^3.5.0
         version: 3.5.0
       type-plus:
-        specifier: ^7.6.2
-        version: 7.6.2
+        specifier: ^8.0.0-beta.10
+        version: 8.0.0-beta.10(typescript@6.0.3)
     devDependencies:
       '@repobuddy/storybook':
         specifier: ^2.32.0
@@ -4904,6 +4904,9 @@ packages:
   tersify@3.12.1:
     resolution: {integrity: sha512-VwzXGHZSOB4T27s4uvh9v8FYrNXyfVz0nBQi28TDwrZoQwT8ZJUp1W2Ff73ekN07stJSb0D+pr6iXeNeFqTI6Q==}
 
+  tersify@4.0.6:
+    resolution: {integrity: sha512-+z2dTeRvbPyI7qiAmBY+VgWnhhN9IuaGjgrPfeF33hI4A/Yd9KT11tbc4l8vfIA3L/5EWiE0swvxOfAckGRuzA==}
+
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
@@ -5013,6 +5016,11 @@ packages:
   type-plus@7.6.2:
     resolution: {integrity: sha512-qUlXv9Y0/W56pg38m275IMD3WA03QbVoqNY16S3kmwtuA4gOT2iheyUdOp8NWrmXWpf7om98hzr7AZD/eW2jLA==}
 
+  type-plus@8.0.0-beta.10:
+    resolution: {integrity: sha512-ZdhzmQg7f8oxt5Cbivslk8o3zef8L3ibpKIeGH1ESf73y8ZEY1z9fe4Z3fTxcjmFOb8ESE1TbW/MCgEvpeLC4w==}
+    peerDependencies:
+      typescript: '>= 5.6.0'
+
   type-plus@8.0.0-beta.7:
     resolution: {integrity: sha512-LTV9UqBJ20I48Ba2L8N25EOowtrs40MLzsqQFfvAXnPAN9z0ny4CjduFfNIfW7euZ6wr6ImShEtrhR1virHiNw==}
 
@@ -5054,6 +5062,10 @@ packages:
   unpartial@1.0.6:
     resolution: {integrity: sha512-wY7h80NSwbITWPXBzd2SSEz0lltFzx5e0mH+M4u0TPebaCwJgujdsZd86oMp5oNIlYBg5RXzMn64/JOxwpFf3w==}
     engines: {node: '>=6'}
+
+  unpartial@1.0.7:
+    resolution: {integrity: sha512-DeyxEI3KSlmDihGAk3Js/p/Ca886ymIz39pWH3VVV/LZ36MsRETylFS37fdzWBWDjMlzB63Rdy2KLCdetOMPig==}
+    engines: {node: '>= 20'}
 
   unplugin@2.3.11:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
@@ -9283,6 +9295,11 @@ snapshots:
       is-buffer: 2.0.5
       unpartial: 1.0.6
 
+  tersify@4.0.6:
+    dependencies:
+      acorn: 8.18.0
+      unpartial: 1.0.7
+
   text-decoder@1.2.7:
     dependencies:
       b4a: 1.8.1
@@ -9388,6 +9405,12 @@ snapshots:
       tersify: 3.12.1
       unpartial: 1.0.6
 
+  type-plus@8.0.0-beta.10(typescript@6.0.3):
+    dependencies:
+      tersify: 4.0.6
+      typescript: 6.0.3
+      unpartial: 1.0.7
+
   type-plus@8.0.0-beta.7:
     dependencies:
       tersify: 3.12.1
@@ -9419,6 +9442,8 @@ snapshots:
   unicorn-magic@0.3.0: {}
 
   unpartial@1.0.6: {}
+
+  unpartial@1.0.7: {}
 
   unplugin@2.3.11:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,18 @@ packages:
 minimumReleaseAge: 1440
 minimumReleaseAgeStrict: true
 
+minimumReleaseAgeExclude:
+  # type-plus@8.0.0-beta.10 fixes the CJS packaging defect in beta.8 that broke
+  # require() of these packages. Taken before the 24h soak elapses; it is a
+  # first-party dependency published via npm trusted publishing with SLSA
+  # provenance (verified).
+  - 'type-plus@8.0.0-beta.10'
+  # Required by type-plus@8.0.0-beta.10 (tersify ^4.0.6, unpartial ^1.0.7); no
+  # older version satisfies those ranges. Both are first-party and published
+  # with SLSA provenance (verified).
+  - 'tersify@4.0.6'
+  - 'unpartial@1.0.7'
+
 allowBuilds:
   '@parcel/watcher': true
   edgedriver: true


### PR DESCRIPTION
Reverses the type-plus part of 6f65e20 (#858). **Only** the type-plus-related parts — the Dependabot/Mergify/`.npmrc` changes from that commit are untouched.

## Why

These packages belong on the type-plus **8.x** line. v8 is effectively stable and is the line the author maintains. Moving them to `^7.6.2` was the wrong fix.

What *was* genuinely wrong is that the dependency was an **exact pin** (`8.0.0-beta.8`), so it could never resolve forward. That is why consumers were stuck on a build with a real CJS packaging defect: `8.0.0-beta.8` declares `"type": "module"` but ships a `cjs/` build with no `{"type":"commonjs"}` marker, so `require()` of these packages fails with `ReferenceError: exports is not defined in ES module scope`.

`type-plus@8.0.0-beta.10` ships `cjs/package.json` with `{"type":"commonjs"}` and fixes that.

## What changed

- `storybook-addon-vis` and `vitest-plugin-vis`: `type-plus` `^7.6.2` → `^8.0.0-beta.10`. A **range**, not a pin — `>=8.0.0-beta.10 <9.0.0-0` picks up later betas and stable 8.x on its own.
- Removed the Renovate packageRule pinning type-plus to `<8.0.0-0`. It would block exactly the updates this now wants. Every other rule is intact.
- `minimumReleaseAgeExclude`: three exact-version entries. The 24h soak refuses `type-plus@8.0.0-beta.10` (~10h old) plus its required `tersify@4.0.6` and `unpartial@1.0.7`, for which no older version satisfies type-plus 8's ranges. All three are first-party, published via npm trusted publishing with SLSA provenance (verified). Strict mode stays on; the list stays exact-version, not a widened waiver.
- Patch changeset for both packages — this is a runtime `dependencies` entry, so consumers need it.

## Notes

- The `8.0.0-beta.10` root barrel (`esm/index.d.ts`) is byte-identical to `8.0.0-beta.8`'s, so there is no API change between them.
- The local `Merge` alias in `vis_server_context.types.ts` is **left in place**. type-plus 8 does export `Merge` from its root, so it could be removed — but a local alias is version-independent and harmless, and removing it only adds risk.
- `pnpm verify` green locally: 20/20 turbo tasks, no snapshot changes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014RLRX3QtRpgCfDt16KShQC