### PR TITLE
chore: drop the three expired soak exclusions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,18 +9,6 @@ packages:
 minimumReleaseAge: 1440
 minimumReleaseAgeStrict: true
 
-minimumReleaseAgeExclude:
-  # type-plus@8.0.0-beta.10 fixes the CJS packaging defect in beta.8 that broke
-  # require() of these packages. Taken before the 24h soak elapses; it is a
-  # first-party dependency published via npm trusted publishing with SLSA
-  # provenance (verified).
-  - 'type-plus@8.0.0-beta.10'
-  # Required by type-plus@8.0.0-beta.10 (tersify ^4.0.6, unpartial ^1.0.7); no
-  # older version satisfies those ranges. Both are first-party and published
-  # with SLSA provenance (verified).
-  - 'tersify@4.0.6'
-  - 'unpartial@1.0.7'
-
 allowBuilds:
   '@parcel/watcher': true
   edgedriver: true


### PR DESCRIPTION
The three exclusions added on 2026-09-02 to admit `type-plus@8.0.0-beta.10` have expired. All three published **2026-09-01**, so the 24h window elapsed on 2026-09-02.

- `type-plus@8.0.0-beta.10`
- `tersify@4.0.6` — required by beta.10 (`tersify: ^4.0.6`), no older version satisfies it
- `unpartial@1.0.7` — same, `unpartial: ^1.0.7`

`minimumReleaseAge: 1440` and `minimumReleaseAgeStrict: true` are untouched; this only removes the waivers, so the soak now governs strictly more than it did.

**No younger resolution can sneak in:** `8.0.0-beta.10` is still `dist-tags.beta`.

## Verified

```
pnpm install --frozen-lockfile   -> resolves with the soak governing all three
git status                       -> pnpm-workspace.yaml only; lockfile unchanged
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETjy9oQGyETyFmDBdR9Egz