### PR TITLE
fix: add the prepare script so husky actually installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"cs": "changeset",
 		"knip": "knip --config .knip.jsonc",
 		"nuke": "turbo nuke && rimraf node_modules",
+		"prepare": "husky",
 		"release": "pnpm build && changeset publish",
 		"sav": "pnpm --filter=./packages/storybook-addon-vis",
 		"t:t": "turbo t:t",


### PR DESCRIPTION
`husky` is in `devDependencies` and `.husky/commit-msg` exists, but there is **no `prepare` or `postinstall` script**, so husky never runs and `core.hooksPath` is never set. The hook has never fired — neither commitlint nor the `pnpm check` this repo runs on commit.

## Measured in a clean clone

```
before   core.hooksPath unset     malformed commit -> exit 0, committed happily
after    core.hooksPath=.husky/_  malformed commit -> exit 1
                                  "husky - commit-msg script failed"
```

## The file mode is not the fault, despite what the audit said

A fleet audit flagged this repo among 11 with a `100644` `.husky/commit-msg`. That premise is wrong for husky 9: the generated `.husky/_` wrapper ends with

```sh
[ ! -f "$s" ] && exit 0
...
sh -e "$s" "$@"
```

— existence check, then `sh`. The executable bit is never consulted. Changing the mode here would have looked like a fix and changed nothing. Seven of those eleven repos were false positives for exactly that reason; this one is real but for a different cause, which is why this PR touches `package.json` and not the hook.

One line, no lockfile change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETjy9oQGyETyFmDBdR9Egz