### PR TITLE
fix(deps): pin type-plus to 8.0.0-beta.10 exactly

### DIFF
--- a/.changeset/type-plus-pin.md
+++ b/.changeset/type-plus-pin.md
@@ -1,0 +1,25 @@
+---
+'storybook-addon-vis': patch
+'vitest-plugin-vis': patch
+---
+
+Pin `type-plus` to `8.0.0-beta.10`, exactly.
+
+Both packages already declared `type-plus: ^8.0.0-beta.10` in the last published release
+(`storybook-addon-vis@4.2.7`, `vitest-plugin-vis@5.1.4`), so this is a range tightening,
+not a version move: `type-plus` 8's `typescript >= 5.6.0` peer already reaches consumers
+today, and this change does not alter what a fresh install resolves — it only forecloses
+later `8.0.0-beta.x` prereleases plus `8.0.0` and `8.1.0`.
+
+The version is pinned rather than caret-ranged. `^8.0.0-beta.10` resolves to
+`>=8.0.0-beta.10 <9.0.0-0`, which admits every later 8.0.0 prerelease as well as `8.0.0`
+and `8.1.0` — and 8 is a prerelease line where breaking changes land between betas
+(beta.10 to beta.11 changed `Equal`'s signature and removed `isType.f`). An exact version
+makes each bump a reviewable PR instead of something a lockfile refresh can do silently.
+Move back to a caret when 8.0.0 is stable.
+
+`type-plus` types leak into each package's emitted declarations:
+`storybook-addon-vis`'s `dist/exports/vitest-plugin.d.mts` imports `Omit` from
+`type-plus`; `vitest-plugin-vis`'s `dist/shared/commands.types.d.mts` and
+`dist/server/testing/stubSuite.d.mts` import `Pick` and `RecursivePartial`. None of
+these symbols changed between 7 and 8, so no source change was needed.

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+	extends: ['@commitlint/config-conventional'],
+	rules: {
+		'body-max-line-length': [0],
+	},
+}

--- a/packages/storybook-addon-vis/package.json
+++ b/packages/storybook-addon-vis/package.json
@@ -85,7 +85,7 @@
 		"is-ci": "^4.1.0",
 		"memoize": "^11.0.0",
 		"pathe": "^2.0.3",
-		"type-plus": "^8.0.0-beta.10",
+		"type-plus": "8.0.0-beta.10",
 		"vitest-plugin-vis": "workspace:^"
 	},
 	"devDependencies": {

--- a/packages/vitest-plugin-vis/package.json
+++ b/packages/vitest-plugin-vis/package.json
@@ -82,7 +82,7 @@
 		"pngjs": "^7.0.0",
 		"rimraf": "^6.1.3",
 		"ssim.js": "^3.5.0",
-		"type-plus": "^8.0.0-beta.10"
+		"type-plus": "8.0.0-beta.10"
 	},
 	"devDependencies": {
 		"@repobuddy/storybook": "^2.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,7 +230,7 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       type-plus:
-        specifier: ^8.0.0-beta.10
+        specifier: 8.0.0-beta.10
         version: 8.0.0-beta.10(typescript@6.0.3)
       vitest-plugin-vis:
         specifier: workspace:^
@@ -366,7 +366,7 @@ importers:
         specifier: ^3.5.0
         version: 3.5.0
       type-plus:
-        specifier: ^8.0.0-beta.10
+        specifier: 8.0.0-beta.10
         version: 8.0.0-beta.10(typescript@6.0.3)
     devDependencies:
       '@repobuddy/storybook':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,3 +41,41 @@ ignoredBuiltDependencies:
   - edgedriver
   - geckodriver
   - msw
+
+# First-party packages are exempt from the soak.
+#
+# The soak exists to stop a COMPROMISED THIRD-PARTY release being pulled into a build
+# within hours of publication. It does not describe our own packages: we control what
+# goes into them, and a first-party release is reviewed before it is published, not
+# after. Applying it to ourselves only means a fresh publish is invisible to the next
+# repo in the chain for 24h.
+minimumReleaseAgeExclude:
+  - assertron
+  - satisfier
+  - tersify
+  - unpartial
+  - type-plus
+  - path-equal
+  - iso-error
+  - iso-error-web
+  - iso-error-google-cloud-api
+  - google-cloud-api
+  - standard-log
+  - standard-log-color
+  - async-fp
+  - fsa-emitter
+  - progress-str
+  - clibuilder
+  - args-minus
+  - global-store
+  - stable-store
+  - mocktomata
+  - just-func
+  - storybook-addon-vis
+  - vitest-plugin-vis
+  - node-supported-releases
+  - '@just-func/*'
+  - '@just-web/*'
+  - '@mocktomata/*'
+  - '@repobuddy/*'
+  - '@unional/*'


### PR DESCRIPTION
## Summary

- Pin `type-plus` from `^8.0.0-beta.10` to exact `8.0.0-beta.10` in both `packages/storybook-addon-vis` and `packages/vitest-plugin-vis` (declared inline in `dependencies`, not via a catalog).
- Add the first-party soak exemption block to `pnpm-workspace.yaml` (`minimumReleaseAgeExclude` did not previously exist, so this adds the key fresh).
- Fix: add a missing `commitlint.config.cjs` (matching sibling repos, e.g. `cyberuni/progress-str`) — the repo runs `commitlint` from a husky `commit-msg` hook but had no config file at all, so every commit was rejected with "Please add rules to your commitlint.config.js". This is a pre-existing repo gap unrelated to the dependency change, fixed in its own commit because it blocked this PR (and every future commit) from landing.

## Bump level

Both `storybook-addon-vis@4.2.7` and `vitest-plugin-vis@5.1.4` already declare `type-plus: ^8.0.0-beta.10` on npm, so this is a pure range-tightening, not a version move — a fresh install resolves the same `type-plus` version before and after. Changeset: **patch** for both.

`type-plus` types do leak into each package's emitted declarations (`storybook-addon-vis`'s `dist/exports/vitest-plugin.d.mts` imports `Omit`; `vitest-plugin-vis`'s `dist/shared/commands.types.d.mts` and `dist/server/testing/stubSuite.d.mts` import `Pick`/`RecursivePartial`), but none of those symbols changed between type-plus 7 and 8.

## Verification

- `pnpm install --frozen-lockfile` passes.
- `pnpm turbo build` passes for both packages.
- `pnpm turbo check` (biome) passes.
- `pnpm why playwright -r` resolves a single version (`1.63.0`), matching the root's exact pin — no playwright hazard here.
- `pnpm why type-plus -r` / `pnpm why tersify -r` show residual duplication only from unswept third-party siblings (`@just-func/types` -> `standard-log` -> `clibuilder` -> `@repobuddy/typescript`), not touched here.
- Pre-existing, unrelated to this change (verified via `git stash` against `main`): the visual-regression suites (`testcase-vpv`, `vitest-plugin-vis` coverage, `storybook-addon-vis` coverage) fail locally with "Snapshot has no baseline image" — checked-in baselines don't match this sandbox's rendering environment. Also pre-existing: `pnpm peers check` reports `typescript@6.0.3` vs `tsdown`/`rolldown-plugin-dts` wanting `^5.0.0`. Neither is introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfdYr4Fj4JzKtUAh88trri
