### PR TITLE
chore: delete the stale .github/mergify.yml

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,1 +1,0 @@
-extends: .github


### PR DESCRIPTION
Part of repobuddy/.github#57.

`.github/mergify.yml` here is `extends: .github`, which has never taken effect: Mergify resolves `.mergify.yml` first, and this repo's `.mergify.yml` already sets `pull_request_rules: []` with the comment explaining why. Deleting the dead file so the repo has exactly one statement of its merge policy.

After repobuddy/monorepo-template#275 this was the last `extends: .github` in the org, which matters because repobuddy/.github#58 empties that org config.

No behaviour change — merging here already runs on Renovate `platformAutomerge` plus GitHub auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wiBz6Vyuos9FW28zoZ9A2